### PR TITLE
Add user information on login

### DIFF
--- a/src/modules/auth/controllers/login.auth.controller.ts
+++ b/src/modules/auth/controllers/login.auth.controller.ts
@@ -29,6 +29,9 @@ export class LoginAuthController {
         expires: new Date(Date.now() + 1000 * 60 * 60 * 24),
         domain: process.env.COOKIE_DOMAIN,
       })
-      .send(authToken);
+      .send({
+        ...authToken,
+        user,
+      });
   }
 }


### PR DESCRIPTION
This avoids having to make a second call immediately after logging in.