### PR TITLE
Add ffmpeg to production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ENV NODE_ENV=${NODE_ENV}
 
 WORKDIR /usr/src/app
 
+RUN apk add ffmpeg
+
 COPY package*.json ./
 
 COPY yarn.lock ./


### PR DESCRIPTION
ffmpeg is currently not included in the production docker. This causes the thumbnail generation endpoint to fail when trying to parse a video. 